### PR TITLE
Fix Earthquake VM Demo instructions

### DIFF
--- a/courses/bdml_fundamentals/demos/earthquakevm/README.md
+++ b/courses/bdml_fundamentals/demos/earthquakevm/README.md
@@ -14,7 +14,7 @@ git clone https://github.com/GoogleCloudPlatform/training-data-analyst
 ```
 * Go to the directory containing demo files and install python packages we need:
 ```
-cd training-data-analyst/courses/bdml_fundamentals
+cd training-data-analyst/courses/bdml_fundamentals/demos/earthquakevm
 ./install_missing.sh
 ```
 * Now, ingest data on recent earthquakes from the USGS:


### PR DESCRIPTION
Update a breaking instruction Earthquake VM Demo.

Changed -

```sh
cd training-data-analyst/courses/bdml_fundamentals
```

to

```sh
cd training-data-analyst/courses/bdml_fundamentals/demos/earthquakevm
```

This would fail to run with existing instructions since the required `.sh` and `.py` files are not present.